### PR TITLE
fix: remove header elements to revert to older version

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Materials Assistant</title>
+    <title>Course Query System</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>
@@ -14,8 +14,6 @@
         <header>
             <div class="header-content">
                 <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
                 </div>
                 <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme" title="Switch between light and dark theme">
                     <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
     <meta http-equiv="Pragma" content="no-cache">
     <meta http-equiv="Expires" content="0">
-    <title>Course Query System</title>
+    <title>Course Materials Assistant</title>
     <link rel="stylesheet" href="style.css?v=9">
 </head>
 <body>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -73,7 +73,6 @@ header {
     justify-content: space-between;
     padding: 1rem 2rem;
     background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
     transition: background-color 0.3s ease, border-color 0.3s ease;
 }
 


### PR DESCRIPTION
- Remove "Course Materials Assistant" h1 header
- Remove subtitle "Ask questions about courses, instructors, and content"
- Remove horizontal border line below header
- Keep the old page title

Resolves #2

🤖 Generated with [Claude Code](https://claude.ai/code)